### PR TITLE
Add PyNaCl dependency to backend dependencies

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -12,11 +12,13 @@ dependencies = [
   "fastapi>=0.111",
   "uvicorn>=0.23",
   "pydantic>=1.10",
-  "python-multipart>=0.0.6"
+  "python-multipart>=0.0.6",
+  "PyNaCl>=1.5"
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8.2",
-  "httpx>=0.27"
+  "httpx>=0.27",
+  "PyNaCl>=1.5"
 ]


### PR DESCRIPTION
## Summary
- add the PyNaCl package to the backend's core dependencies
- include PyNaCl in the backend dev extra to support local testing

## Testing
- pytest server/app/tests

------
https://chatgpt.com/codex/tasks/task_e_68d15e439984832187c0ce0abc7c96fe