### PR TITLE
Bump backend to Pydantic 2

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1207,7 +1207,7 @@ if __name__ == "__main__":
 [project]
 name = "nutrition-scanner-server"
 version = "0.1.0"
-dependencies = ["fastapi==0.115.0","uvicorn[standard]==0.30.6","pydantic==2.8.2"]
+dependencies = ["fastapi==0.115.0","uvicorn[standard]==0.30.6","pydantic>=2.0,<3.0"]
 ```
 
 ```bash

--- a/implementation.md
+++ b/implementation.md
@@ -1207,7 +1207,7 @@ if __name__ == "__main__":
 [project]
 name = "nutrition-scanner-server"
 version = "0.1.0"
-dependencies = ["fastapi==0.115.0","uvicorn[standard]==0.30.6","pydantic==2.8.2"]
+dependencies = ["fastapi==0.115.0","uvicorn[standard]==0.30.6","pydantic>=2.0,<3.0"]
 ```
 
 ```bash

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
   "fastapi>=0.111",
   "uvicorn>=0.23",
-  "pydantic>=1.10",
+  "pydantic>=2.0,<3.0",
   "python-multipart>=0.0.6",
   "PyNaCl>=1.5"
 ]


### PR DESCRIPTION
## Summary
- require Pydantic 2.x for the FastAPI backend and keep the rest of the dependencies unchanged
- update the backend installation docs to reflect the new Pydantic requirement

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d161b97580832187cad21e5818d303