### PR TITLE
Replace UTC constant usage in backend tests

### DIFF
--- a/server/app/tests/test_api.py
+++ b/server/app/tests/test_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 
@@ -41,7 +41,7 @@ def test_telemetry_ingest():
   client = TestClient(app)
   payload = {
     "event": "scan_completed",
-    "timestamp": datetime.now(UTC).isoformat(),
+    "timestamp": datetime.now(timezone.utc).isoformat(),
     "platform": "ios",
     "region": "EU",
     "payload": {"additives": 3, "flags": 1},


### PR DESCRIPTION
## Summary
- replace usage of datetime.UTC with timezone.utc in telemetry ingest test

## Testing
- PYENV_VERSION=3.10.17 pyenv exec pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16d835c3883218f000a7199b46113